### PR TITLE
Fix: Add type hints for pmap in_axes

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1133,12 +1133,14 @@ def _mapped_axis_size(fn, tree, vals, dims, name):
       msg.append(f"  * some axes ({ct} of them) had size {sz}, e.g. axis {ax} of {ex};\n")
   raise ValueError(''.join(msg)[:-2])  # remove last semicolon and newline
 
+from typing import Callable, Sequence, Any, Iterable
+import jaxlib.xla_extension as xc
 
 def pmap(
     fun: Callable,
     axis_name: AxisName | None = None,
     *,
-    in_axes=0,
+    in_axes: int | None | Sequence[Any] = 0,
     out_axes=0,
     static_broadcasted_argnums: int | Iterable[int] = (),
     devices: Sequence[xc.Device] | None = None,  # noqa: F811


### PR DESCRIPTION
The `pmap` function lacked proper type hints for `in_axes`, causing Pyright to raise type errors. 
This PR updates `in_axes` to accept `int | None | Sequence[Any]`, making it consistent with `vmap`.
